### PR TITLE
fix: auto-detect Linux root for Chromium --no-sandbox in shoot.mjs

### DIFF
--- a/plugins/nateherk-design/skills/scrollcraft/CHANGELOG.md
+++ b/plugins/nateherk-design/skills/scrollcraft/CHANGELOG.md
@@ -4,6 +4,24 @@ Dated notes on what changed in the skill and which build's finding drove it.
 Builds live in `OtherWorlds/Ultimate Websites/builds/`; each carries a
 `BUILD-REPORT.md`.
 
+## 2026-08-26: Linux/root Chromium fix in shoot.mjs
+
+Driven by a first Linux build (Debian 12, Node 24) where `chromium.launch()`
+crashed immediately when running as root without `--no-sandbox`.
+
+**Scripts, `scripts/shoot.mjs`**
+
+- `launch()` now auto-detects root (`process.getuid() === 0`) and passes
+  `["--no-sandbox", "--disable-setuid-sandbox"]` automatically. Opt-in
+  override via `SCROLLCRAFT_NO_SANDBOX=1` for non-root setups that still need
+  it. Safe on a private server; never set on shared machines.
+- No behaviour change on macOS or Windows (no `getuid`).
+
+**Finding that drove it:** shoot.mjs exited immediately with a Chromium crash
+log on Debian 12 as root. The harness never opened a page. Adding `--no-sandbox`
+resolved it. Auto-detection on uid=0 means Linux root builds work out of the box
+without any env override.
+
 ## 2026-08-23: iOS clip priming hardened; real-device diagnostic added
 
 Driven by a build whose hero clip sat frozen on the owner's actual iPhone

--- a/plugins/nateherk-design/skills/scrollcraft/scripts/shoot.mjs
+++ b/plugins/nateherk-design/skills/scrollcraft/scripts/shoot.mjs
@@ -67,7 +67,14 @@ if (!CHROME) {
 
 fs.mkdirSync(OUT, { recursive: true });
 
-const browser = await chromium.launch({ executablePath: CHROME, headless: true });
+// Linux/root: set SCROLLCRAFT_NO_SANDBOX=1 if Chromium refuses to start.
+// This is safe on a private server; never set it on a shared/production machine.
+const noSandbox = process.env.SCROLLCRAFT_NO_SANDBOX === "1" || process.getuid?.() === 0;
+const browser = await chromium.launch({
+  executablePath: CHROME,
+  headless: true,
+  args: noSandbox ? ["--no-sandbox", "--disable-setuid-sandbox"] : [],
+});
 const page = await browser.newPage({
   viewport: { width: W, height: H },
   deviceScaleFactor: 2,


### PR DESCRIPTION
Running `shoot.mjs` as root on Linux (e.g. inside a container or VM) caused Chromium to crash immediately.

This patch detects `uid=0` via `process.getuid()` and passes `--no-sandbox` + `--disable-setuid-sandbox` automatically to the Playwright browser launch.

It also accepts `SCROLLCRAFT_NO_SANDBOX=1` as an explicit opt-in for non-root setups that still need it. No behaviour change on macOS or Windows.

Tested on: Debian 12 (PVE), Node 24, Chromium, root user.